### PR TITLE
[PKG-3014] jinjasql 0.1.8  :snowflake:

### DIFF
--- a/recipe/fix_jinja2.patch
+++ b/recipe/fix_jinja2.patch
@@ -1,0 +1,133 @@
+From 0108a3a258851b678d337dbd2cddfc75db5350c2 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Thu, 12 Oct 2023 14:11:22 +0300
+Subject: [PATCH] Fix jinja2
+
+---
+ jinjasql/core.py | 27 +++++++++++++--------------
+ requirements.txt |  2 +-
+ setup.py         |  2 +-
+ 3 files changed, 15 insertions(+), 16 deletions(-)
+
+diff --git a/jinjasql/core.py b/jinjasql/core.py
+index f7ecec1..d2214ed 100644
+--- a/jinjasql/core.py
++++ b/jinjasql/core.py
+@@ -3,7 +3,7 @@ from jinja2 import Environment
+ from jinja2 import Template
+ from jinja2.ext import Extension
+ from jinja2.lexer import Token
+-from jinja2.utils import Markup
++from markupsafe import Markup
+ 
+ try:
+     from collections import OrderedDict
+@@ -48,18 +48,18 @@ class SqlExtension(Extension):
+ 
+     def filter_stream(self, stream):
+         """
+-        We convert 
++        We convert
+         {{ some.variable | filter1 | filter 2}}
+-            to 
++            to
+         {{ ( some.variable | filter1 | filter 2 ) | bind}}
+-        
++
+         ... for all variable declarations in the template
+ 
+         Note the extra ( and ). We want the | bind to apply to the entire value, not just the last value.
+         The parentheses are mostly redundant, except in expressions like {{ '%' ~ myval ~ '%' }}
+ 
+-        This function is called by jinja2 immediately 
+-        after the lexing stage, but before the parser is called. 
++        This function is called by jinja2 immediately
++        after the lexing stage, but before the parser is called.
+         """
+         while not stream.eos:
+             token = next(stream)
+@@ -73,10 +73,10 @@ class SqlExtension(Extension):
+                 last_token = var_expr[-1]
+                 lineno = last_token.lineno
+                 # don't bind twice
+-                if (not last_token.test("name") 
++                if (not last_token.test("name")
+                     or not last_token.value in ('bind', 'inclause', 'sqlsafe')):
+                     param_name = self.extract_param_name(var_expr)
+-                    
++
+                     var_expr.insert(1, Token(lineno, 'lparen', u'('))
+                     var_expr.append(Token(lineno, 'rparen', u')'))
+                     var_expr.append(Token(lineno, 'pipe', u'|'))
+@@ -97,10 +97,10 @@ def sql_safe(value):
+     return Markup(value)
+ 
+ def bind(value, name):
+-    """A filter that prints %s, and stores the value 
++    """A filter that prints %s, and stores the value
+     in an array, so that it can be bound using a prepared statement
+ 
+-    This filter is automatically applied to every {{variable}} 
++    This filter is automatically applied to every {{variable}}
+     during the lexing stage, so developers can't forget to bind
+     """
+     if isinstance(value, Markup):
+@@ -110,13 +110,13 @@ def bind(value, name):
+             Did you forget to apply '|inclause' to your query?""")
+     else:
+         return _bind_param(_thread_local.bind_params, name, value)
+-    
++
+ def bind_in_clause(value):
+     values = list(value)
+     results = []
+     for v in values:
+         results.append(_bind_param(_thread_local.bind_params, "inclause", v))
+-    
++
+     clause = ",".join(results)
+     clause = "(" + clause + ")"
+     return clause
+@@ -125,7 +125,7 @@ def _bind_param(already_bound, key, value):
+     _thread_local.param_index += 1
+     new_key = "%s_%s" % (key, _thread_local.param_index)
+     already_bound[new_key] = value
+-    
++
+     param_style = _thread_local.param_style
+     if param_style == 'qmark':
+         return "?"
+@@ -164,7 +164,6 @@ class JinjaSql(object):
+     def _prepare_environment(self):
+         self.env.autoescape=True
+         self.env.add_extension(SqlExtension)
+-        self.env.add_extension('jinja2.ext.autoescape')
+         self.env.filters["bind"] = bind
+         self.env.filters["sqlsafe"] = sql_safe
+         self.env.filters["inclause"] = bind_in_clause
+diff --git a/requirements.txt b/requirements.txt
+index 8d495d4..aa837e8 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,3 +1,3 @@
+-Jinja2>=2.5
++Jinja2>=2.8
+ Django>=1.7,<1.8
+ PyYAML>=3
+\ No newline at end of file
+diff --git a/setup.py b/setup.py
+index a02f39c..93acda6 100644
+--- a/setup.py
++++ b/setup.py
+@@ -39,7 +39,7 @@ sdict = {
+     'packages' : ['jinjasql'],
+     'test_suite' : 'tests.all_tests',
+     'install_requires': [
+-        'Jinja2>=2.5'
++        'Jinja2>=2.8'
+     ],
+     'classifiers' : [
+         'Development Status :: 4 - Beta',
+-- 
+2.39.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # conda.exceptions.UnsatisfiableError for python 3.11
+  skip: true  # [py>310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,37 +6,51 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5ba8fc1ce0c037da0b3e122d4bbc7b8fd47e1fa73ec72ef72c4c495f81f042a1
+  url: https://github.com/sripathikrishnan/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 91d2362311443bcff6d91fc948e932d346f4ab738006c64adb1e4d4323f679b6
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - jinja2 >=2.5
+    # Use the upper bound <3.0.0 because otherwise tests will fail
+    - jinja2 >=2.5,<3.0.0
 
 test:
   imports:
     - jinjasql
+  source_files:
+    - tests/
+    - run_tests
+  requires:
+    - django
+    - pip
+    - pytest
+    - pyyaml
+  commands:
+    - pip check
+    - python run_tests
 
 about:
   home: https://github.com/hashedin/jinjasql
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Template Language for SQL with Automatic Bind Parameter Extraction'
+  summary: Template Language for SQL with Automatic Bind Parameter Extraction
   description: |
     JinjaSQL is a template language for SQL statements and scripts. Since it's
     based in Jinja2, you have all the power it offers - conditional statements,
     macros, looping constructs, blocks, inheritance, and many more.
   dev_url: https://github.com/hashedin/jinjasql
+  doc_url: https://github.com/hashedin/jinjasql
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,14 +8,17 @@ package:
 source:
   url: https://github.com/sripathikrishnan/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 91d2362311443bcff6d91fc948e932d346f4ab738006c64adb1e4d4323f679b6
+  patches:
+    - fix_jinja2.patch
 
 build:
   number: 0
-  # conda.exceptions.UnsatisfiableError for python 3.11
-  skip: true  # [py>310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - python
     - pip
@@ -23,8 +26,7 @@ requirements:
     - wheel
   run:
     - python
-    # Use the upper bound <3.0.0 because otherwise tests will fail
-    - jinja2 >=2.5,<3.0.0
+    - jinja2 >=2.8
 
 test:
   imports:
@@ -42,7 +44,7 @@ test:
     - python run_tests
 
 about:
-  home: https://github.com/hashedin/jinjasql
+  home: https://github.com/sripathikrishnan/jinjasql
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -51,8 +53,8 @@ about:
     JinjaSQL is a template language for SQL statements and scripts. Since it's
     based in Jinja2, you have all the power it offers - conditional statements,
     macros, looping constructs, blocks, inheritance, and many more.
-  dev_url: https://github.com/hashedin/jinjasql
-  doc_url: https://github.com/hashedin/jinjasql
+  dev_url: https://github.com/sripathikrishnan/jinjasql
+  doc_url: https://github.com/sripathikrishnan/jinjasql
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| conda-forge | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jinjasql.svg)](https://anaconda.org/conda-forge/jinjasql) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jinjasql.svg)](https://anaconda.org/conda-forge/jinjasql) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jinjasql.svg)](https://anaconda.org/conda-forge/jinjasql) | ![Conda License](https://img.shields.io/conda/l/conda-forge/jinjasql) |

Changelog: https://github.com/sripathikrishnan/jinjasql/releases
License: https://github.com/sripathikrishnan/jinjasql/blob/v0.1.8/LICENSE
Requirements: 
- https://github.com/sripathikrishnan/jinjasql/blob/v0.1.8/setup.py
- tests https://github.com/sripathikrishnan/jinjasql/blob/v0.1.8/requirements.txt

Actions:
1. Apply `recipe/fix_jinja2.patch` to fix jinja2 versions and compatibility with `markupsafe`, see also https://github.com/sripathikrishnan/jinjasql/pull/51
2. Clean up the recipe
3. Add a test suite
4. Update home, dev & doc urls

Notes:
- `jinjasql` is no longer maintained, see https://github.com/sripathikrishnan/jinjasql/issues/50#issuecomment-1657230029, but the fork `jinjasql2` that is actively maintained also exists, see https://github.com/pythonutilities/jinjasql